### PR TITLE
Install boto3 in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
 WORKDIR /app
 COPY . /app
 RUN python3 setup.py test
-RUN pip3 install .
+RUN pip3 install . && pip3 install boto3
 
 COPY planetutils.sh /scripts/planetutils.sh
 


### PR DESCRIPTION
Since 68f81dd5cf boto3 is an optional dependency. However, that breaks the `--s3` flag when running via Docker.

This installs boto3 as part of the Dockerfile so that it's always there.