### PR TITLE
Speed Improvement

### DIFF
--- a/planetutils/elevation_tile_downloader.py
+++ b/planetutils/elevation_tile_downloader.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python
 from __future__ import absolute_import, unicode_literals
-import os
-import subprocess
-import math
 
-from . import download
-from . import log
-from .bbox import validate_bbox
+import concurrent
+import os
+import math
+from retry import retry
+from concurrent import futures
+from multiprocessing.pool import ThreadPool
+from urllib.request import urlopen
+
+from planetutils import download
+from planetutils import log
+from planetutils.bbox import validate_bbox
 
 def makedirs(path):
     try:
@@ -15,6 +20,8 @@ def makedirs(path):
         pass
 
 class ElevationDownloader(object):
+    zoom = 0
+
     def __init__(self, outpath='.'):
         self.outpath = outpath
 
@@ -24,36 +31,46 @@ class ElevationDownloader(object):
     def download_bboxes(self, bboxes):
         for name, bbox in bboxes.items():
             self.download_bbox(bbox)
-    
+
     def download_bbox(self, bbox, bucket='elevation-tiles-prod', prefix='geotiff'):
         tiles = self.get_bbox_tiles(bbox)
         found = set()
         download = set()
-        for z,x,y in tiles:
+        for z, x, y in tiles:
             od = self.tile_path(z, x, y)
             op = os.path.join(self.outpath, *od)
             if self.tile_exists(op):
-                found.add((x,y))
+                found.add((x, y))
             else:
-                download.add((x,y))
-        log.info("found %s tiles; %s to download"%(len(found), len(download)))
-        for x,y in sorted(download):
-            self.download_tile(bucket, prefix, z, x, y)
+                download.add((x, y))
+        log.info("found %s tiles; %s to download" % (len(found), len(download)))
+        tasks = {self._tile_url_path(bucket, prefix, self.zoom, x, y) for x, y in sorted(download)}
+
+        with futures.ThreadPoolExecutor() as executor:
+            # Start the load operations and mark each future with its URL
+            future_to_url = {
+                executor.submit(self._download_multi, url_op): url_op for url_op in tasks
+            }
+            for future in futures.as_completed(future_to_url):
+                try:
+                    future.result()
+                except Exception as exc:
+                    log.error('generated an exception: %s' % exc)
+                    pass
 
     def tile_exists(self, op):
         if os.path.exists(op):
             return True
 
-    def download_tile(self, bucket, prefix, z, x, y, suffix=''):
+    def _tile_url_path(self, bucket, prefix, z, x, y, suffix=''):
         od = self.tile_path(z, x, y)
         op = os.path.join(self.outpath, *od)
         makedirs(os.path.join(self.outpath, *od[:-1]))
         if prefix:
             od = [prefix]+od
-        url = 'http://s3.amazonaws.com/%s/%s%s'%(bucket, '/'.join(od), suffix)
-        log.info("downloading %s to %s"%(url, op))
-        self._download(url, op)
-        
+        url = 'http://s3.amazonaws.com/%s/%s%s' % (bucket, '/'.join(od), suffix)
+        return url, op
+
     def tile_path(self, z, x, y):
         raise NotImplementedError
 
@@ -62,6 +79,19 @@ class ElevationDownloader(object):
 
     def _download(self, url, op):
         download.download(url, op)
+
+    @staticmethod
+    @retry(exceptions=Exception, tries=5, delay=2, backoff=2, logger=log)
+    def _download_multi(url_op):
+        url, op = url_op
+        log.info("downloading %s to %s" % (url, op))
+        request = urlopen(url, timeout=10)
+        with open(op, 'wb') as f:
+            try:
+                f.write(request.read())
+            except Exception as exc:
+                raise Exception("Error downloading %r - %s", (url, exc))
+
 
 class ElevationGeotiffDownloader(ElevationDownloader):
     def __init__(self, *args, **kwargs):
@@ -80,7 +110,7 @@ class ElevationGeotiffDownloader(ElevationDownloader):
         size = 2**self.zoom
         xt = lambda x:int((x + 180.0) / 360.0 * size)
         yt = lambda y:int((1.0 - math.log(math.tan(math.radians(y)) + (1 / math.cos(math.radians(y)))) / math.pi) / 2.0 * size)
-        tiles = []    
+        tiles = []
         for x in range(xt(left), xt(right)+1):
             for y in range(yt(top), yt(bottom)+1):
                 tiles.append([self.zoom, x, y])
@@ -89,9 +119,10 @@ class ElevationGeotiffDownloader(ElevationDownloader):
     def tile_path(self, z, x, y):
         return list(map(str, [z, x, str(y)+'.tif']))
 
+
 class ElevationSkadiDownloader(ElevationDownloader):
     HGT_SIZE = (3601 * 3601 * 2)
-    
+
     def get_bbox_tiles(self, bbox):
         left, bottom, right, top = validate_bbox(bbox)
         min_x = int(math.floor(left))
@@ -104,13 +135,13 @@ class ElevationSkadiDownloader(ElevationDownloader):
             for y in range(min_y, max_y):
                 tiles.add((0, x, y))
         return tiles
-    
+
     def tile_exists(self, op):
-        if os.path.exists(op) and os.stat(op).st_size == self.HGT_SIZE:	
+        if os.path.exists(op) and os.stat(op).st_size == self.HGT_SIZE:
             return True
 
     def download_tile(self, bucket, prefix, z, x, y, suffix=''):
-        super(ElevationSkadiDownloader, self).download_tile(bucket, 'skadi', z, x, y, suffix='.gz')
+        super(ElevationSkadiDownloader, self)._tile_url_path(bucket, 'skadi', z, x, y, suffix='.gz')
 
     def tile_path(self, z, x, y):
         ns = lambda i:'S%02d'%abs(i) if i < 0 else 'N%02d'%abs(i)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name='interline-planetutils',
     author_email='ian@interline.io',
     license='MIT',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
-    install_requires=['future', 'requests'], #, 'osmium', 'boto3'
+    install_requires=['future', 'requests', 'retry'], #, 'osmium', 'boto3'
     tests_require=['nose'],
     test_suite = 'nose.collector',
     entry_points={


### PR DESCRIPTION
This is probably not ready for an out-right merge but I want to bring it to you attention that it's possible to 10x the speed of tile downloads.

I'm able to achieve 450 tiles/sec (680Mbps) with this new method while downloading zooms 12, 13, 14 as separate commands. These stats are with an 8 CPU server, SSD (0% IO-Wait). So the limitation is my bandwidth.

Perhaps you want to incorporate this method into the larger download mechanisms.