### PR TITLE
Use HTTPS for S3 terrain tile download

### DIFF
--- a/planetutils/elevation_tile_downloader.py
+++ b/planetutils/elevation_tile_downloader.py
@@ -50,7 +50,7 @@ class ElevationDownloader(object):
         makedirs(os.path.join(self.outpath, *od[:-1]))
         if prefix:
             od = [prefix]+od
-        url = 'http://s3.amazonaws.com/%s/%s%s'%(bucket, '/'.join(od), suffix)
+        url = 'https://s3.amazonaws.com/%s/%s%s'%(bucket, '/'.join(od), suffix)
         log.info("downloading %s to %s"%(url, op))
         self._download(url, op)
         


### PR DESCRIPTION
This PR resolves #38. When using `http://` URLs for fetching terrain tiles from S3, it response with `AccessDenied`. Using HTTPS instead works.